### PR TITLE
Experimental implementation of SymBasisSetsCompact

### DIFF
--- a/src/symfc/matrix_funcs.py
+++ b/src/symfc/matrix_funcs.py
@@ -1,0 +1,93 @@
+"""Functions to handle matrix indices."""
+import numpy as np
+
+import symfc._symfc as symfcc
+
+
+def to_serial(i: int, a: int, j: int, b: int, natom: int) -> int:
+    """Return NN33-1D index."""
+    return (i * 9 * natom) + (j * 9) + (a * 3) + b
+
+
+def transform_n3n3_serial_to_nn33_serial(n3n3_serial, natom) -> int:
+    """Convert N3N3-1D index to NN33-1D index."""
+    return to_serial(*_transform_n3n3_serial(n3n3_serial, natom))
+
+
+def convert_basis_sets_matrix_form(basis_sets) -> list[np.ndarray]:
+    """Convert basis sets to matrix form."""
+    b_mat_all = []
+    for b in basis_sets:
+        b_seq = b.transpose((0, 2, 1, 3))
+        b_mat = b_seq.reshape(
+            (b_seq.shape[0] * b_seq.shape[1], b_seq.shape[2] * b_seq.shape[3])
+        )
+        b_mat_all.append(b_mat)
+    return b_mat_all
+
+
+def kron_c(reps, natom) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute kron(r, r) in NN33 order in C.
+
+    See the details about this method in _step1_kron_py_for_c.
+
+    Note
+    ----
+    At some version of scipy, dtype of coo_array.col and coo_array.row changed.
+    Here the dtype is assumed 'intc' (<1.11) or 'int_' (>=1.11).
+
+    """
+    size = 0
+    for rmat in reps:
+        size += rmat.row.shape[0] ** 2
+    row_dtype = reps[0].row.dtype
+    col_dtype = reps[0].col.dtype
+    data_dtype = reps[0].data.dtype
+    row = np.zeros(size, dtype=row_dtype)
+    col = np.zeros(size, dtype=col_dtype)
+    data = np.zeros(size, dtype=data_dtype)
+    row_dtype = reps[0].row.dtype
+    col_dtype = reps[0].col.dtype
+    assert row_dtype is np.dtype("intc") or row_dtype is np.dtype("int_")
+    assert reps[0].row.flags.contiguous
+    assert col_dtype is np.dtype("intc") or col_dtype is np.dtype("int_")
+    assert reps[0].col.flags.contiguous
+    assert data_dtype == np.dtype("double")
+    assert reps[0].data.flags.contiguous
+    i_shift = 0
+    for rmat in reps:
+        if col_dtype is np.dtype("intc") and row_dtype is np.dtype("intc"):
+            symfcc.kron_nn33_int(
+                row[i_shift:],
+                col[i_shift:],
+                data[i_shift:],
+                rmat.row,
+                rmat.col,
+                rmat.data,
+                3 * natom,
+            )
+        elif col_dtype is np.dtype("int_") and row_dtype is np.dtype("int_"):
+            symfcc.kron_nn33_long(
+                row[i_shift:],
+                col[i_shift:],
+                data[i_shift:],
+                rmat.row,
+                rmat.col,
+                rmat.data,
+                3 * natom,
+            )
+        else:
+            raise RuntimeError("Incompatible data type of rows and cols of coo_array.")
+        i_shift += rmat.row.shape[0] ** 2
+    data /= len(reps)
+
+    return row, col, data
+
+
+def _transform_n3n3_serial(serial_id: int, natom: int) -> tuple[int, int, int, int]:
+    """Decode 1D index to (N, 3, N, 3) indices."""
+    b = serial_id % 3
+    j = (serial_id // 3) % natom
+    a = (serial_id // (3 * natom)) % 3
+    i = serial_id // (9 * natom)
+    return i, a, j, b, natom

--- a/src/symfc/symfc_compact.py
+++ b/src/symfc/symfc_compact.py
@@ -1,0 +1,123 @@
+"""Generate symmetrized force constants using compact projection matrix."""
+from typing import Optional
+
+import numpy as np
+import scipy
+from scipy.sparse import coo_array
+
+from symfc.matrix_funcs import convert_basis_sets_matrix_form, kron_c, to_serial
+from symfc.symfc import get_projector_constraints
+
+
+class SymBasisSetsCompact:
+    """Compact symmetry adapted basis sets for force constants."""
+
+    def __init__(
+        self,
+        reps: list[coo_array],
+        log_level: int = 0,
+    ):
+        """Init method.
+
+        Parameters
+        ----------
+        reps : list[coo_array]
+            Matrix representations of symmetry operations.
+        log_level : int, optional
+            Log level. Default is 0.
+
+        """
+        self._reps: list[coo_array] = reps
+        self._log_level = log_level
+
+        self._natom = int(round(self._reps[0].shape[0] / 3))
+
+        self._basis_sets: Optional[np.ndarray] = None
+
+        self._run()
+
+    @property
+    def basis_sets_matrix_form(self) -> Optional[list[np.ndarray]]:
+        """Retrun a list of FC basis in 3Nx3N matrix."""
+        if self._basis_sets is None:
+            return None
+
+        return convert_basis_sets_matrix_form(self._basis_sets)
+
+    @property
+    def basis_sets(self) -> Optional[np.ndarray]:
+        """Return a list of FC basis in (N, N, 3, 3) dimentional arrays."""
+        return self._basis_sets
+
+    def _run(self, tol: float = 1e-8):
+        row, col, data = kron_c(self._reps, self._natom)
+        size_sq = (3 * self._natom) ** 2
+        proj_mat = coo_array(
+            (data, (row, col)), shape=(size_sq, size_sq), dtype="double"
+        )
+        perm_mat = _get_permutation_compression_matrix(self._natom)
+
+        perm_proj_mat = (perm_mat @ proj_mat) @ perm_mat.T
+        rank = int(round(perm_proj_mat.diagonal(k=0).sum()))
+        print("Solving eigenvalue problem of projection matrix.")
+        vals, vecs = scipy.sparse.linalg.eigsh(perm_proj_mat, k=rank, which="LM")
+        # vals, vecs = np.linalg.eigh(perm_proj_mat.toarray())
+        nonzero_cols = np.where(np.isclose(vals, 1.0, rtol=0, atol=tol))[0]
+        vecs = vecs[:, nonzero_cols]
+        if self._log_level:
+            print(
+                f" eigenvalues of projector = {vals}, len(nonzero-vals)={vecs.shape[1]}"
+            )
+        proj_const = get_projector_constraints(self._natom, with_permutation=False)
+
+        # checking commutativity of two projectors
+        comm = proj_mat.dot(proj_const) - proj_const.dot(proj_mat)
+        if np.all(np.abs(comm.data) < tol) is False:
+            raise ValueError("Two projectors do not satisfy commutation rule.")
+        U = proj_const.dot(perm_mat.T @ vecs)
+        U, s, _ = np.linalg.svd(U, full_matrices=False)
+        U = U[:, np.where(np.abs(s) > tol)[0]]
+
+        if self._log_level:
+            print(f"  - svd eigenvalues = {np.abs(s)}")
+            print("  - basis size = ", U.shape)
+
+        fc_basis = [b.reshape((self._natom, self._natom, 3, 3)) for b in U.T]
+        self._basis_sets = np.array(fc_basis, dtype="double", order="C")
+
+
+def _get_permutation_compression_matrix(natom: int) -> coo_array:
+    """Return compression matrix by permutation matrix.
+
+    Matrix shape is ((N*3)((N*3)+1)/2, NN33).
+    Non-zero only ijab and jiba column elements for ijab rows.
+    Rows upper right NN33 matrix elements are selected for rows.
+
+    """
+    row, col, data = [], [], []
+    size = natom**2 * 9
+
+    count = 0
+    for i_i in range(natom):
+        for i_j in range(natom):
+            if i_i > i_j:
+                continue
+            for i_a in range(3):
+                for i_b in range(3):
+                    if i_i == i_j and i_a > i_b:
+                        continue
+                    row.append(count)
+                    col.append(to_serial(i_i, i_a, i_j, i_b, natom))
+                    if i_i == i_j and i_a == i_b:
+                        data.append(1)
+                    else:
+                        data.append(np.sqrt(2) / 2)
+                        row.append(count)
+                        col.append(to_serial(i_j, i_b, i_i, i_a, natom))
+                        data.append(np.sqrt(2) / 2)
+                    count += 1
+    if (natom * 3) % 2 == 1:
+        assert (natom * 3) * ((natom * 3 + 1) // 2) == count, f"{natom}, {count}"
+    else:
+        assert ((natom * 3) // 2) * (natom * 3 + 1) == count, f"{natom}, {count}"
+    return coo_array((data, (row, col)), shape=(count, size), dtype="double")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import phonopy
 import pytest
 
 from symfc.symfc import SymBasisSets, SymOpReps
+from symfc.symfc_compact import SymBasisSetsCompact
 
 cwd = Path(__file__).parent
 
@@ -128,4 +129,105 @@ def bs_gan_222() -> np.ndarray:
         log_level=1,
     )
     sbs = SymBasisSets(sym_op_reps.representations, log_level=1, lang="C")
+    return sbs.basis_sets
+
+
+#
+# Compact form
+#
+@pytest.fixture(scope="session")
+def bs_nacl_222_compact() -> np.ndarray:
+    """Return basis sets of NaCl222."""
+    ph = phonopy.load(cwd / "phonopy_NaCl_222_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_sno2_223_compact() -> np.ndarray:
+    """Return basis sets of SnO2-223."""
+    ph = phonopy.load(cwd / "phonopy_SnO2_223_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_sno2_222_compact() -> np.ndarray:
+    """Return basis sets of SnO2-222."""
+    ph = phonopy.load(cwd / "phonopy_SnO2_222_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_sio2_222_compact() -> np.ndarray:
+    """Return basis sets of SiO2-222."""
+    ph = phonopy.load(cwd / "phonopy_SiO2_222_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_sio2_221_compact() -> np.ndarray:
+    """Return basis sets of SiO2-221."""
+    ph = phonopy.load(cwd / "phonopy_SiO2_221_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_gan_442_compact() -> np.ndarray:
+    """Return basis sets of GaN-442."""
+    ph = phonopy.load(cwd / "phonopy_GaN_442_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
+    return sbs.basis_sets
+
+
+@pytest.fixture(scope="session")
+def bs_gan_222_compact() -> np.ndarray:
+    """Return basis sets of GaN-222."""
+    ph = phonopy.load(cwd / "phonopy_GaN_222_rd.yaml.xz", produce_fc=False)
+    sym_op_reps = SymOpReps(
+        ph.supercell.cell.T,
+        ph.supercell.scaled_positions.T,
+        ph.supercell.numbers,
+        log_level=1,
+    )
+    sbs = SymBasisSetsCompact(sym_op_reps.representations, log_level=1)
     return sbs.basis_sets

--- a/tests/test_symfc_compact.py
+++ b/tests/test_symfc_compact.py
@@ -5,16 +5,13 @@ import numpy as np
 import phonopy
 import pytest
 
-from symfc.symfc import SymBasisSets, SymOpReps
+from symfc.symfc import SymOpReps
+from symfc.symfc_compact import SymBasisSetsCompact
 
 cwd = Path(__file__).parent
 
 
-@pytest.mark.parametrize(
-    "lang,use_exact_projection_matrix",
-    [("Py", False), ("Py_for_C", False), ("C", False), ("C", True)],
-)
-def test_fc_basis_sets(lang, use_exact_projection_matrix):
+def test_fc_basis_sets_compact():
     """Test symmetry adapted basis sets of FC."""
     basis_ref = [
         [-0.28867513, 0, 0, 0.28867513, 0, 0],
@@ -31,20 +28,18 @@ def test_fc_basis_sets(lang, use_exact_projection_matrix):
 
     sym_op_reps = SymOpReps(lattice, positions, types, log_level=1)
     rep = sym_op_reps.representations
-    sbs = SymBasisSets(
+    sbs = SymBasisSetsCompact(
         rep,
-        use_exact_projection_matrix=use_exact_projection_matrix,
         log_level=1,
-        lang=lang,
     )
     basis = sbs.basis_sets_matrix_form
     np.testing.assert_allclose(basis[0], basis_ref, atol=1e-6)
     assert np.linalg.norm(basis[0]) == pytest.approx(1.0)
 
 
-def test_fc_NaCl_222(bs_nacl_222: np.ndarray):
+def test_fc_NaCl_222(bs_nacl_222_compact: np.ndarray):
     """Test force constants by NaCl 64 atoms supercell."""
-    basis_sets = bs_nacl_222
+    basis_sets = bs_nacl_222_compact
     ph = phonopy.load(cwd / "phonopy_NaCl_222_rd.yaml.xz", produce_fc=False)
     f = ph.dataset["forces"]
     d = ph.dataset["displacements"]
@@ -81,79 +76,79 @@ def test_fc_NaCl_222(bs_nacl_222: np.ndarray):
     np.testing.assert_allclose(ph_ref.force_constants, fc_compact, atol=1e-6)
 
 
-def test_fc_NaCl_222_wrt_ALM(bs_nacl_222: np.ndarray):
+def test_fc_NaCl_222_wrt_ALM(bs_nacl_222_compact: np.ndarray):
     """Test force constants by NaCl 64 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_NaCl_222_rd.yaml.xz", bs_nacl_222)
+    _compare_fc_with_alm("phonopy_NaCl_222_rd.yaml.xz", bs_nacl_222_compact)
 
 
 @pytest.mark.big
-def test_fc_SnO2_223_wrt_ALM(bs_sno2_223: np.ndarray):
+def test_fc_SnO2_223_wrt_ALM(bs_sno2_223_compact: np.ndarray):
     """Test force constants by SnO2 72 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_SnO2_223_rd.yaml.xz", bs_sno2_223)
+    _ = _compare_fc_with_alm("phonopy_SnO2_223_rd.yaml.xz", bs_sno2_223_compact)
 
 
-def test_fc_SnO2_222_wrt_ALM(bs_sno2_222: np.ndarray):
+def test_fc_SnO2_222_wrt_ALM(bs_sno2_222_compact: np.ndarray):
     """Test force constants by SnO2 48 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_SnO2_222_rd.yaml.xz", bs_sno2_222)
+    _ = _compare_fc_with_alm("phonopy_SnO2_222_rd.yaml.xz", bs_sno2_222_compact)
 
 
 @pytest.mark.big
-def test_fc_SiO2_222_wrt_ALM(bs_sio2_222: np.ndarray):
+def test_fc_SiO2_222_wrt_ALM(bs_sio2_222_compact: np.ndarray):
     """Test force constants by SiO2 72 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_SiO2_222_rd.yaml.xz", bs_sio2_222)
+    _ = _compare_fc_with_alm("phonopy_SiO2_222_rd.yaml.xz", bs_sio2_222_compact)
     # _write_phonopy_fc_yaml(
     #     "phonopy_SiO2_222_fc.yaml", "phonopy_SiO2_222_rd.yaml.xz", fc_compact
     # )
 
 
-def test_fc_SiO2_221_wrt_ALM(bs_sio2_221: np.ndarray):
+def test_fc_SiO2_221_wrt_ALM(bs_sio2_221_compact: np.ndarray):
     """Test force constants by SiO2 36 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_SiO2_221_rd.yaml.xz", bs_sio2_221)
+    _ = _compare_fc_with_alm("phonopy_SiO2_221_rd.yaml.xz", bs_sio2_221_compact)
     # _write_phonopy_fc_yaml(
     #     "phonopy_SiO2_221_fc.yaml", "phonopy_SiO2_221_rd.yaml.xz", fc_compact
     # )
 
 
 @pytest.mark.big
-def test_fc_GaN_442_wrt_ALM(bs_gan_442: np.ndarray):
+def test_fc_GaN_442_wrt_ALM(bs_gan_442_compact: np.ndarray):
     """Test force constants by GaN 128 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_GaN_442_rd.yaml.xz", bs_gan_442)
+    _ = _compare_fc_with_alm("phonopy_GaN_442_rd.yaml.xz", bs_gan_442_compact)
     # _write_phonopy_fc_yaml(
     #     "phonopy_GaN_442_fc.yaml", "phonopy_GaN_442_rd.yaml.xz", fc_compact
     # )
 
 
-def test_fc_GaN_222_wrt_ALM(bs_gan_222: np.ndarray):
+def test_fc_GaN_222_wrt_ALM(bs_gan_222_compact: np.ndarray):
     """Test force constants by GaN 32 atoms supercell and compared with ALM.
 
     This test is skipped when ALM is not installed.
 
     """
-    _ = _compare_fc_with_alm("phonopy_GaN_222_rd.yaml.xz", bs_gan_222)
+    _ = _compare_fc_with_alm("phonopy_GaN_222_rd.yaml.xz", bs_gan_222_compact)
     # _write_phonopy_fc_yaml(
     #     "phonopy_GaN_222_fc.yaml", "phonopy_GaN_222_rd.yaml.xz", fc_compact
     # )


### PR DESCRIPTION
Permutation symmetry matrix given below is multiplied from left and right to projection matrix, then diagonalize it. After that, translational symmetry is applied as a constraint, but not permutation symmetry.

Each column of permutation symmetry matrix $\mathrm{P}_\mathrm{perm}$ is defined such as
```math
\frac{1}{\sqrt{2}}[0, \cdots, 0, 1, 0, \cdots, 0, 1, 0, \cdots, 0]^\mathrm{T}
```
The matrix shape is $(N^2, N(N+1)/2)$, where N=(natom*3)**2. The following matrix multiplication gives identity matrix:

```math
\mathrm{P}_\mathrm{perm}\mathrm{P}_\mathrm{perm}^\mathrm{T}=\mathrm{I}_{N^2}
```

 This is implemented in `symfc.symfc_compact._get_permutation_compression_matrix`.  Whether this works or not theoretically has not proved yet.