### PR TITLE
Lower memory usage option though slow computation

### DIFF
--- a/src/symfc/basis_set.py
+++ b/src/symfc/basis_set.py
@@ -60,17 +60,18 @@ class FCBasisSet:
         self._log_level = log_level
         self._basis_set: Optional[np.ndarray] = None
 
+    @property
     def basis_set_matrix_form(self) -> Optional[list[np.ndarray]]:
         """Retrun basis set in (n_basis, 3N, 3N) array."""
-        return convert_basis_set_matrix_form(self.fc_basis_set)
+        return convert_basis_set_matrix_form(self.basis_set)
 
     @property
-    def fc_basis_set(self) -> Optional[np.ndarray]:
+    def basis_set(self) -> Optional[np.ndarray]:
         """Return basis set in (n_basis, N, N, 3, 3) array."""
         return self._get_fc_basis_set()
 
     @property
-    def basis_set(self) -> Optional[np.ndarray]:
+    def compressed_basis_set(self) -> Optional[np.ndarray]:
         """Return basi set in (n_a * N * 9, n_basis) array."""
         return self._basis_set
 

--- a/src/symfc/basis_set.py
+++ b/src/symfc/basis_set.py
@@ -1,5 +1,6 @@
 """Generate symmetrized force constants using compact projection matrix."""
-from typing import Optional
+import time
+from typing import Literal, Optional
 
 import numpy as np
 import scipy
@@ -8,8 +9,10 @@ from scipy.sparse import coo_array
 from symfc.spg_reps import SpgReps
 from symfc.utils import (
     convert_basis_set_matrix_form,
-    get_compression_spg_proj,
-    get_lattice_translation_compression_matrix,
+    get_indep_atoms_by_lat_trans,
+    get_lat_trans_compr_matrix,
+    get_lat_trans_compr_matrix_block_i,
+    get_spg_projector,
 )
 
 
@@ -29,7 +32,12 @@ class FCBasisSet:
 
     """
 
-    def __init__(self, spg_reps: SpgReps, log_level: int = 0):
+    def __init__(
+        self,
+        spg_reps: SpgReps,
+        mode: Literal["fast", "lowmem"] = "fast",
+        log_level: int = 0,
+    ):
         """Init method.
 
         Parameters
@@ -39,39 +47,43 @@ class FCBasisSet:
         translation_permutations:
             Atom indices after lattice translations.
             shape=(lattice_translations, supercell_atoms)
+        mode : Lietral["fast", "lowmem"]
+            With "fact", basis set is computed faster but with more memory usage
+            and with "lowmem" slower but less memory usage. Default is "fast".
         log_level : int, optional
             Log level. Default is 0.
 
         """
         self._spg_reps = spg_reps
-        # self._reps: list[coo_array] = spg_reps.representations
+        self._mode = mode
         self._natom = len(self._spg_reps.numbers)
         self._log_level = log_level
         self._basis_set: Optional[np.ndarray] = None
 
-    @property
     def basis_set_matrix_form(self) -> Optional[list[np.ndarray]]:
-        """Retrun a list of FC basis in 3Nx3N matrix."""
-        if self._basis_set is None:
-            return None
+        """Retrun basis set in (n_basis, 3N, 3N) array."""
+        return convert_basis_set_matrix_form(self.fc_basis_set)
 
-        return convert_basis_set_matrix_form(self._basis_set)
+    @property
+    def fc_basis_set(self) -> Optional[np.ndarray]:
+        """Return basis set in (n_basis, N, N, 3, 3) array."""
+        return self._get_fc_basis_set()
 
     @property
     def basis_set(self) -> Optional[np.ndarray]:
-        """Return a list of FC basis in (N, N, 3, 3) dimentional arrays."""
+        """Return basi set in (n_a * N * 9, n_basis) array."""
         return self._basis_set
 
-    def run(
-        self,
-        tol: float = 1e-8,
-    ):
+    @property
+    def compression_matrix(self) -> coo_array:
+        """Return compression matrix."""
+        return get_lat_trans_compr_matrix(self._spg_reps.translation_permutations)
+
+    def run(self, tol: float = 1e-8):
         """Compute force constants basis."""
         if self._log_level:
             print("Construct compression matrix of lattice translation.")
-        compression_mat = get_lattice_translation_compression_matrix(
-            self._spg_reps.translation_permutations
-        )
+        compression_mat = self.compression_matrix
         vecs = self._step1(compression_mat, tol=tol)
         U = self._step2(vecs, compression_mat)
         self._step3(U, compression_mat, tol=tol)
@@ -94,29 +106,80 @@ class FCBasisSet:
         """
         if self._log_level:
             print(
-                "Construct projector of product of space group and "
-                "index permutation symmetry."
+                "Construct projector matrix of space group and "
+                "index permutation symmetry..."
             )
-        compression_spg_mat = get_compression_spg_proj(
+        compression_spg_mat = get_spg_projector(
             self._spg_reps,
             self._natom,
             compression_mat,
         )
         rank = int(round(compression_spg_mat.diagonal(k=0).sum()))
         if self._log_level:
-            print(f"Solving eigenvalue problem of projection matrix (rank={rank}).")
+            N, N_c = compression_mat.shape
+            print(f"Projection matrix ({N}, {N}) was compressed to ({N_c}, {N_c}).")
+            print(
+                f"Solving eigenvalue problem of projection matrix with rank={rank}..."
+            )
         vals, vecs = scipy.sparse.linalg.eigsh(compression_spg_mat, k=rank, which="LM")
-        nonzero_elems = np.nonzero(np.abs(vals) > tol)[0]
-        vals = vals[nonzero_elems]
         # Check non-zero values are all ones. This is a weak check of
         # commutativity.
         np.testing.assert_allclose(vals, 1.0, rtol=0, atol=tol)
-        vecs = vecs[:, nonzero_elems]
-        if self._log_level:
-            print(f" eigenvalues of projector = {vals}")
         return vecs
 
     def _step2(self, vecs: np.ndarray, compression_mat: coo_array) -> np.ndarray:
+        if self._mode == "fast":
+            return self._step2_fast(vecs, compression_mat)
+        elif self._mode == "lowmem":
+            return self._step2_lowmem(vecs, compression_mat)
+        else:
+            raise RuntimeError("This should not happen.")
+
+    def _step2_lowmem(self, vecs: np.ndarray, compression_mat: coo_array) -> np.ndarray:
+        if self._log_level:
+            print("Multiply sum rule projector with current basis set...")
+        n_l, N = self._spg_reps.translation_permutations.shape
+        n_a = N // n_l
+        U_sum = np.zeros(shape=(n_a, 9 * N, vecs.shape[1]), dtype="double")
+        for i_lattice in range(n_l):
+            U_sum += self._get_U_i_lat(i_lattice, n_a, vecs)
+        return U_sum.reshape(n_a * 9 * N, -1)
+
+    def _get_U_i_lat(
+        self,
+        i_lattice: int,
+        n_a: int,
+        vecs: np.ndarray,
+    ):
+        if self._log_level:
+            print(f"---------{i_lattice}---------")
+        t0 = time.time()
+        compr_block = get_lat_trans_compr_matrix_block_i(
+            self._spg_reps.translation_permutations, i_lattice
+        )
+        if self._log_level:
+            print("compr_block", compr_block.shape, time.time() - t0)
+        t1 = time.time()
+        U = compr_block @ vecs.reshape(n_a, self._natom * 9, vecs.shape[1])
+        t2 = time.time()
+        if self._log_level:
+            print("compr_block @ vecs", U.shape, t2 - t1)
+        prod = U.reshape(n_a, self._natom, 9, -1).sum(axis=1) / self._natom
+        t3 = time.time()
+        if self._log_level:
+            print("sum", prod.shape, t3 - t2)
+        for j in range(self._natom):
+            U[:, j * 9 : (j + 1) * 9, :] -= prod
+        t4 = time.time()
+        if self._log_level:
+            print("loop", t4 - t3)
+        U = compr_block.T @ U
+        t5 = time.time()
+        if self._log_level:
+            print("compr_block.T @ U", U.shape, t5 - t4)
+        return U
+
+    def _step2_fast(self, vecs: np.ndarray, compression_mat: coo_array) -> np.ndarray:
         """Multiply sum rule project to basis vectors.
 
         Compute P_sum B, where
@@ -128,7 +191,8 @@ class FCBasisSet:
         and B is the set of fc basis vectors determined by P_SG and P_perm.
 
         """
-        print("Multiply sum rule projector")
+        if self._log_level:
+            print("Multiply sum rule projector with current basis set...")
         U = compression_mat @ vecs
         for i in range(self._natom):
             prod = (
@@ -149,14 +213,62 @@ class FCBasisSet:
         rejected.
 
         """
-        print("Solving SVD")
+        if self._log_level:
+            print("Accomodate sum rule by SVD...")
+
         U, s, _ = np.linalg.svd(U, full_matrices=False)
         U = U[:, np.where(np.abs(s) > 1 - tol)[0]]
 
         if self._log_level:
-            print(f"  - svd eigenvalues = {np.abs(s)}")
-            print(f"  - basis size = {U.shape}")
+            print("Excluded SVD eigenvalues:")
+            print(f"{s[np.abs(s) < 1 - tol]}")
+            print(f"Final size of basis set: {U.shape}")
 
-        self._basis_set = (compression_mat @ U).T.reshape(
-            (U.shape[1], self._natom, self._natom, 3, 3)
+        self._basis_set = U
+
+    def _get_compact_fc_basis_set(self) -> Optional[np.ndarray]:
+        if self._basis_set is None:
+            return None
+
+        trans_perms = self._spg_reps.translation_permutations
+        n_l, N = trans_perms.shape
+        n_a = N // n_l
+        # fc_basis_set = np.zeros(
+        #     (self._basis_set.shape[1], len(indep_atoms), N, 3, 3), dtype="double"
+        # )
+        compr_block = get_lat_trans_compr_matrix_block_i(
+            self._spg_reps.translation_permutations, 0
         )
+        basis_part = compr_block @ self._basis_set.reshape(n_a, N * 9, -1)
+        fc_basis_set = basis_part.reshape(n_a * N * 9, -1).T.reshape(-1, n_a, N, 3, 3)
+        return fc_basis_set
+
+    def _get_fc_basis_set(self) -> Optional[np.ndarray]:
+        if self._basis_set is None:
+            return None
+        if self._mode == "lowmem":
+            trans_perms = self._spg_reps.translation_permutations
+            indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
+            n_l, N = trans_perms.shape
+            n_a = N // n_l
+            fc_basis_set = np.zeros(
+                (self._basis_set.shape[1], N, N, 3, 3), dtype="double"
+            )
+            for i_lattice in range(n_l):
+                if self._log_level:
+                    print(f"{i_lattice}")
+                compr_block = get_lat_trans_compr_matrix_block_i(
+                    self._spg_reps.translation_permutations, i_lattice
+                )
+                basis_part = compr_block @ self._basis_set.reshape(n_a, N * 9, -1)
+                fc_basis_set[
+                    :, trans_perms[i_lattice, indep_atoms], :, :, :
+                ] = basis_part.reshape(n_a * N * 9, -1).T.reshape(-1, n_a, N, 3, 3)
+            return fc_basis_set
+        elif self._mode == "fast":
+            fc_basis_set = (self.compression_matrix @ self._basis_set).T.reshape(
+                (self._basis_set.shape[1], self._natom, self._natom, 3, 3)
+            )
+            return fc_basis_set
+        else:
+            raise RuntimeError("This should not happen.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,8 @@ def ph_gan_222() -> Phonopy:
 
 
 @pytest.fixture(scope=scope)
-def bs_nacl_222_compact() -> FCBasisSet:
-    """Return basis sets of NaCl222."""
+def bs_nacl_222() -> FCBasisSet:
+    """Return basis set of NaCl222."""
     ph = phonopy.load(cwd / "phonopy_NaCl_222_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -74,7 +74,7 @@ def bs_nacl_222_compact() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_sno2_223() -> FCBasisSet:
-    """Return basis sets of SnO2-223."""
+    """Return basis set of SnO2-223."""
     ph = phonopy.load(cwd / "phonopy_SnO2_223_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -87,7 +87,7 @@ def bs_sno2_223() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_sno2_222() -> FCBasisSet:
-    """Return basis sets of SnO2-222."""
+    """Return basis set of SnO2-222."""
     ph = phonopy.load(cwd / "phonopy_SnO2_222_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -100,7 +100,7 @@ def bs_sno2_222() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_sio2_222() -> FCBasisSet:
-    """Return basis sets of SiO2-222."""
+    """Return basis set of SiO2-222."""
     ph = phonopy.load(cwd / "phonopy_SiO2_222_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -113,7 +113,7 @@ def bs_sio2_222() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_sio2_221() -> FCBasisSet:
-    """Return basis sets of SiO2-221."""
+    """Return basis set of SiO2-221."""
     ph = phonopy.load(cwd / "phonopy_SiO2_221_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -126,7 +126,7 @@ def bs_sio2_221() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_gan_442() -> FCBasisSet:
-    """Return basis sets of GaN-442."""
+    """Return basis set of GaN-442."""
     ph = phonopy.load(cwd / "phonopy_GaN_442_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,
@@ -139,7 +139,7 @@ def bs_gan_442() -> FCBasisSet:
 
 @pytest.fixture(scope=scope)
 def bs_gan_222() -> FCBasisSet:
-    """Return basis sets of GaN-222."""
+    """Return basis set of GaN-222."""
     ph = phonopy.load(cwd / "phonopy_GaN_222_rd.yaml.xz", produce_fc=False)
     sym_op_reps = SpgReps(
         ph.supercell.cell.T,

--- a/tests/test_basis_set.py
+++ b/tests/test_basis_set.py
@@ -11,7 +11,7 @@ from symfc.spg_reps import SpgReps
 cwd = Path(__file__).parent
 
 
-def test_fc_basis_sets_compact():
+def test_fc_basis_set():
     """Test symmetry adapted basis sets of FC."""
     basis_ref = [
         [-0.28867513, 0, 0, 0.28867513, 0, 0],
@@ -34,7 +34,7 @@ def test_fc_basis_sets_compact():
     assert np.linalg.norm(basis[0]) == pytest.approx(1.0)
 
 
-def test_fc_NaCl_222(bs_nacl_222_compact: FCBasisSet):
+def test_fc_NaCl_222(bs_nacl_222: FCBasisSet):
     """Test force constants by NaCl 64 atoms supercell and compared with ALM.
 
     Also test force constants by NaCl 64 atoms supercell.
@@ -43,7 +43,7 @@ def test_fc_NaCl_222(bs_nacl_222_compact: FCBasisSet):
 
 
     """
-    basis_set = bs_nacl_222_compact.run().basis_set
+    basis_set = bs_nacl_222.run().basis_set
     ph = phonopy.load(cwd / "phonopy_NaCl_222_rd.yaml.xz", produce_fc=False)
     f = ph.dataset["forces"]
     d = ph.dataset["displacements"]
@@ -79,7 +79,7 @@ def test_fc_NaCl_222(bs_nacl_222_compact: FCBasisSet):
     ph_ref = phonopy.load(cwd / "phonopy_NaCl_222_fc.yaml.xz", produce_fc=False)
     np.testing.assert_allclose(ph_ref.force_constants, fc_compact, atol=1e-6)
 
-    _ = _compare_fc_with_alm("phonopy_NaCl_222_rd.yaml.xz", bs_nacl_222_compact)
+    _ = _compare_fc_with_alm("phonopy_NaCl_222_rd.yaml.xz", bs_nacl_222)
     # _write_phonopy_fc_yaml(
     #     "phonopy_NaCl_222_fc.yaml", "phonopy_NaCl_222_rd.yaml.xz", fc_compact
     # )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from phonopy import Phonopy
 
 from symfc.spg_reps import SpgReps
-from symfc.utils import get_indep_atoms_by_lattice_translation
+from symfc.utils import get_indep_atoms_by_lat_trans
 
 
 def test_get_indep_atoms_by_lattice_translation(ph_nacl_222: Phonopy):
@@ -16,5 +16,5 @@ def test_get_indep_atoms_by_lattice_translation(ph_nacl_222: Phonopy):
         ph.supercell.numbers,
     )
     trans_perms = sym_op_reps.translation_permutations
-    indep_atoms = get_indep_atoms_by_lattice_translation(trans_perms)
+    indep_atoms = get_indep_atoms_by_lat_trans(trans_perms)
     np.testing.assert_array_equal(indep_atoms, [0, 32])


### PR DESCRIPTION
Expansion of compressed basis set results in high memory usage. Therefore, direct solution of coefficients of compressed basis set with respect to input displacements-forces dataset has to be investigated.