### PR TITLE
Efficient reordering of dot products in solver_O3 and solver_O2O3

### DIFF
--- a/src/symfc/solvers/solver_O2O3.py
+++ b/src/symfc/solvers/solver_O2O3.py
@@ -49,7 +49,7 @@ def get_training_exact(
 
     t1 = time.time()
     full_basis_fc2 = compress_mat_fc2 @ compress_eigvecs_fc2
-    X2, y = get_training_from_full_basis(
+    X2, y_all = get_training_from_full_basis(
         disps, forces, full_basis_fc2.T.reshape((n_basis_fc2, N, N, 3, 3))
     )
     t2 = time.time()
@@ -63,29 +63,34 @@ def get_training_exact(
     print(" reshape (compr_mat_fc3):", t2 - t1)
 
     sparse_disps = True if use_mkl else False
+    mat33 = np.zeros((n_compr_fc3, n_compr_fc3), dtype=float)
+    mat23 = np.zeros((n_basis_fc2, n_compr_fc3), dtype=float)
+    mat3y = np.zeros(n_compr_fc3, dtype=float)
     begin_batch, end_batch = get_batch_slice(disps.shape[0], batch_size)
-    XTX = np.zeros((n_basis, n_basis), dtype=float)
-    XTy = np.zeros(n_basis, dtype=float)
-
-    XTX[:n_basis_fc2, :n_basis_fc2] = X2.T @ X2
-    XTy[:n_basis_fc2] = X2.T @ y
     for begin, end in zip(begin_batch, end_batch):
         t01 = time.time()
         disps_batch = set_2nd_disps(disps[begin:end], sparse=sparse_disps)
-        X3 = (
-            dot_product_sparse(
-                disps_batch, compress_mat_fc3, use_mkl=use_mkl, dense=True
-            ).reshape((-1, n_compr_fc3))
-            @ compress_eigvecs_fc3
-        )
-        y = forces[begin:end].reshape(-1)
-        XTX[:n_basis_fc2, n_basis_fc2:] += X2[begin * N3 : end * N3].T @ X3
-        XTX[n_basis_fc2:, n_basis_fc2:] += X3.T @ X3
-        XTy[n_basis_fc2:] += X3.T @ y
+        X3 = dot_product_sparse(
+            disps_batch, compress_mat_fc3, use_mkl=use_mkl, dense=True
+        ).reshape((-1, n_compr_fc3))
+        y_batch = forces[begin:end].reshape(-1)
+        mat23 += X2[begin * N3 : end * N3].T @ X3
+        mat33 += X3.T @ X3
+        mat3y += X3.T @ y_batch
         t02 = time.time()
         print(" solver_block:", end, ":, t =", t02 - t01)
 
+    XTX = np.zeros((n_basis, n_basis), dtype=float)
+    XTy = np.zeros(n_basis, dtype=float)
+    XTX[:n_basis_fc2, :n_basis_fc2] = X2.T @ X2
+    XTX[:n_basis_fc2, n_basis_fc2:] = mat23 @ compress_eigvecs_fc3
     XTX[n_basis_fc2:, :n_basis_fc2] = XTX[:n_basis_fc2, n_basis_fc2:].T
+    XTX[n_basis_fc2:, n_basis_fc2:] = (
+        compress_eigvecs_fc3.T @ mat33 @ compress_eigvecs_fc3
+    )
+    XTy[:n_basis_fc2] = X2.T @ y_all
+    XTy[n_basis_fc2:] = compress_eigvecs_fc3.T @ mat3y
+
     t3 = time.time()
     print(" (disp @ compr @ eigvecs).T @ (disp @ compr @ eigvecs):", t3 - t2)
     return XTX, XTy


### PR DESCRIPTION
Dot products with compress_eigvecs are reordered more efficiently in solver_O3.py and solver_O2O3.py.
Useless functions for approximately solving force constants are removed.