### PR TITLE
Built-in PhonopyAtoms (SymfcAtoms) and compute_sg_permutations

### DIFF
--- a/src/symfc/api_symfc.py
+++ b/src/symfc/api_symfc.py
@@ -5,10 +5,10 @@ from collections.abc import Sequence
 from typing import Optional, Union
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 
 from symfc.basis_sets import FCBasisSetBase, FCBasisSetO2Slow
 from symfc.solvers import FCSolverO2
+from symfc.utils.utils import SymfcAtoms
 
 
 class Symfc:
@@ -16,14 +16,14 @@ class Symfc:
 
     def __init__(
         self,
-        supercell: PhonopyAtoms,
+        supercell: SymfcAtoms,
         displacements: Optional[np.ndarray] = None,
         forces: Optional[np.ndarray] = None,
         orders: Optional[Sequence[int]] = None,
         log_level: int = 0,
     ):
         """Init method."""
-        self._supercell: PhonopyAtoms = supercell
+        self._supercell: SymfcAtoms = supercell
         self._displacements: Optional[np.ndarray] = displacements
         self._forces: Optional[np.ndarray] = forces
         self._log_level = log_level

--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -6,7 +6,6 @@ from typing import Optional, Union
 
 import numpy as np
 import scipy
-from phonopy.structure.atoms import PhonopyAtoms
 from scipy.sparse import coo_array, csr_array
 
 from symfc.spg_reps import SpgRepsO2
@@ -16,6 +15,7 @@ from symfc.utils.eig_tools import (
     eigsh_projector_sumrule,
 )
 from symfc.utils.matrix_tools_O2 import compressed_projector_sum_rules
+from symfc.utils.utils import SymfcAtoms
 from symfc.utils.utils_O2 import (
     get_compr_coset_reps_sum,
     get_lat_trans_compr_indices,
@@ -58,14 +58,14 @@ class FCBasisSetO2Slow(FCBasisSetBase):
 
     def __init__(
         self,
-        supercell: PhonopyAtoms,
+        supercell: SymfcAtoms,
         log_level: int = 0,
     ):
         """Init method.
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
         log_level : int, optional
             Log level. Default is 0.
@@ -218,7 +218,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
     def __init__(
         self,
-        supercell: PhonopyAtoms,
+        supercell: SymfcAtoms,
         use_mkl: bool = False,
         log_level: int = 0,
     ):
@@ -226,7 +226,7 @@ class FCBasisSetO2(FCBasisSetBase):
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
         log_level : int, optional
             Log level. Default is 0.

--- a/src/symfc/basis_sets/basis_sets_O3.py
+++ b/src/symfc/basis_sets/basis_sets_O3.py
@@ -5,7 +5,6 @@ import time
 from typing import Optional, Union
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 from scipy.sparse import coo_array, csc_array, csr_array
 
 from symfc.spg_reps import SpgRepsO3
@@ -18,6 +17,7 @@ from symfc.utils.matrix_tools_O3 import (
     compressed_projector_sum_rules,
     get_perm_compr_matrix_O3,
 )
+from symfc.utils.utils import SymfcAtoms
 from symfc.utils.utils_O3 import (
     get_compr_coset_reps_sum_O3,
     get_lat_trans_compr_matrix_O3,
@@ -56,7 +56,7 @@ class FCBasisSetO3(FCBasisSetBase):
 
     def __init__(
         self,
-        supercell: PhonopyAtoms,
+        supercell: SymfcAtoms,
         use_mkl: bool = False,
         log_level: int = 0,
     ):
@@ -64,7 +64,7 @@ class FCBasisSetO3(FCBasisSetBase):
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
         log_level : int, optional
             Log level. Default is 0.

--- a/src/symfc/basis_sets/basis_sets_base.py
+++ b/src/symfc/basis_sets/basis_sets_base.py
@@ -5,9 +5,9 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 
 from symfc.spg_reps import SpgRepsBase
+from symfc.utils.utils import SymfcAtoms
 
 
 class FCBasisSetBase(ABC):
@@ -15,7 +15,7 @@ class FCBasisSetBase(ABC):
 
     def __init__(
         self,
-        supercell: PhonopyAtoms,
+        supercell: SymfcAtoms,
         use_mkl: bool = False,
         log_level: int = 0,
     ):
@@ -23,7 +23,7 @@ class FCBasisSetBase(ABC):
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
         log_level : int, optional
             Log level. Default is 0.

--- a/src/symfc/spg_reps/spg_reps_O1.py
+++ b/src/symfc/spg_reps/spg_reps_O1.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 from scipy.sparse import csr_array
+
+from symfc.utils.utils import SymfcAtoms
 
 from .spg_reps_base import SpgRepsBase
 
@@ -11,12 +12,12 @@ from .spg_reps_base import SpgRepsBase
 class SpgRepsO1(SpgRepsBase):
     """Class of reps of space group operations for fc1."""
 
-    def __init__(self, supercell: PhonopyAtoms):
+    def __init__(self, supercell: SymfcAtoms):
         """Init method.
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
 
         """

--- a/src/symfc/spg_reps/spg_reps_O2.py
+++ b/src/symfc/spg_reps/spg_reps_O2.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 from scipy.sparse import csr_array
+
+from symfc.utils.utils import SymfcAtoms
 
 from .spg_reps_base import SpgRepsBase
 
@@ -11,12 +12,12 @@ from .spg_reps_base import SpgRepsBase
 class SpgRepsO2(SpgRepsBase):
     """Class of reps of space group operations for fc2."""
 
-    def __init__(self, supercell: PhonopyAtoms):
+    def __init__(self, supercell: SymfcAtoms):
         """Init method.
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
 
         """

--- a/src/symfc/spg_reps/spg_reps_O3.py
+++ b/src/symfc/spg_reps/spg_reps_O3.py
@@ -2,21 +2,21 @@
 from __future__ import annotations
 
 import numpy as np
-from phonopy.structure.atoms import PhonopyAtoms
 from scipy.sparse import csr_array
 
 from symfc.spg_reps import SpgRepsBase
+from symfc.utils.utils import SymfcAtoms
 
 
 class SpgRepsO3(SpgRepsBase):
     """Class of reps of space group operations for fc3."""
 
-    def __init__(self, supercell: PhonopyAtoms):
+    def __init__(self, supercell: SymfcAtoms):
         """Init method.
 
         Parameters
         ----------
-        supercell : PhonopyAtoms
+        supercell : SymfcAtoms
             Supercell.
 
         """

--- a/src/symfc/utils/utils.py
+++ b/src/symfc/utils/utils.py
@@ -31,3 +31,179 @@ def get_indep_atoms_by_lat_trans(trans_perms: np.ndarray) -> np.ndarray:
         if not is_found:
             unique_atoms.append(i)
     return np.array(unique_atoms, dtype=int)
+
+
+def compute_sg_permutations(
+    positions: np.ndarray,  # scaled positions
+    rotations: np.ndarray,  # scaled
+    translations: np.ndarray,  # scaled
+    lattice: np.ndarray,  # column vectors
+    symprec: float,
+):
+    """Compute permutations of atoms by space group operations in supercell.
+
+    This code is obtained from the implemention in phonopy, and modified to
+    avoid using the C implementation.
+
+    Parameters
+    ----------
+    positions : ndarray
+        Scaled positions (like SymfcAtoms.scaled_positions) before applying
+        the space group operation
+    rotations : ndarray
+        Matrix (rotation) parts of space group operations
+        shape=(len(operations), 3, 3), dtype='intc'
+    translations : ndarray
+        Vector (translation) parts of space group operations
+        shape=(len(operations), 3), dtype='double'
+    lattice : ndarray
+        Basis vectors in column vectors (like SymfcAtoms.cell.T)
+    symprec : float
+        Symmetry tolerance of the distance unit
+
+    Returns
+    -------
+    perms : ndarray
+        shape=(len(translations), len(positions)), dtype='intc', order='C'
+
+    """
+    out = []
+    for sym, t in zip(rotations, translations):
+        rotated_positions = positions @ sym.T + t
+        out.append(
+            _compute_permutation_for_translation(
+                positions, rotated_positions, lattice, symprec
+            )
+        )
+    return np.array(out, dtype="intc", order="C")
+
+
+def _compute_permutation_for_translation(
+    positions_a: np.ndarray,
+    positions_b: np.ndarray,
+    lattice: np.ndarray,
+    symprec: float,  # scaled positions  # column vectors
+):
+    """Get the overall permutation such that.
+
+        positions_a[perm[i]] == positions_b[i]   (modulo the lattice)
+
+    or in numpy speak,
+
+        positions_a[perm] == positions_b   (modulo the lattice)
+
+    This version is optimized for the case where positions_a and positions_b
+    are related by a rotation.
+
+    Parameters
+    ----------
+    positions_a : ndarray
+        Scaled positions (like SymfcAtoms.scaled_positions) before applying
+        the space group operation
+    positions_b : ndarray
+        Scaled positions (like SymfcAtoms.scaled_positions) after applying
+        the space group operation
+    lattice : ndarray
+        Basis vectors in column vectors (like SymfcAtoms.cell.T)
+    symprec : float
+        Symmetry tolerance of the distance unit
+
+    Returns
+    -------
+    perm : ndarray
+        A list of atomic indices that maps atoms before the space group
+        operation to those after as explained above.
+        shape=(len(positions), ), dtype=int
+
+    """
+
+    def sort_by_lattice_distance(fracs):
+        """Sort atoms by distance.
+
+        Sort both sides by some measure which is likely to produce a small
+        maximum value of (sorted_rotated_index - sorted_original_index).
+        The C code is optimized for this case, reducing an O(n^2)
+        search down to ~O(n). (for O(n log n) work overall, including the sort)
+
+        We choose distance from the nearest bravais lattice point as our measure.
+
+        """
+        carts = np.dot(fracs - np.rint(fracs), lattice.T)
+        perm = np.argsort(np.sum(carts**2, axis=1))
+        sorted_fracs = np.array(fracs[perm], dtype="double", order="C")
+        return perm, sorted_fracs
+
+    (perm_a, sorted_a) = sort_by_lattice_distance(positions_a)
+    (perm_b, sorted_b) = sort_by_lattice_distance(positions_b)
+
+    perm_between = _compute_atom_mapping(sorted_a, sorted_b, lattice, symprec)
+
+    # Compose all of the permutations for the full permutation.
+    #
+    # Note the following properties of permutation arrays:
+    #
+    # 1. Inverse:         if  x[perm] == y  then  x == y[argsort(perm)]
+    # 2. Associativity:   x[p][q] == x[p[q]]
+    return perm_a[perm_between][np.argsort(perm_b)]
+
+
+def _compute_atom_mapping(
+    positions_a, positions_b, lattice, symprec  # scaled positions  # column vectors
+):
+    """Return mapping defined by positions_a[perm[i]] == positions_b[i].
+
+    Version of `_compute_permutation_for_rotation` which just directly
+    calls the C function, without any conditioning of the data.
+    Skipping the conditioning step makes this EXTREMELY slow on large
+    structures.
+
+    """
+    atom_mapping = np.zeros(shape=(len(positions_a),), dtype="intc")
+
+    for i, pos_b in enumerate(positions_b):
+        diffs = positions_a - pos_b
+        diffs -= np.rint(diffs)
+        dists = np.linalg.norm(np.dot(diffs, lattice.T), axis=1)
+        possible_j = np.where(dists < symprec)[0]
+        if len(possible_j) != 1:
+            raise ValueError("Mapping atoms failed. Maybe some atoms are too close.")
+        atom_mapping[i] = possible_j[0]
+
+    if -1 in atom_mapping:
+        raise ValueError("Mapping atoms failed. Some atoms could not be mapped.")
+
+    return atom_mapping
+
+
+class SymfcAtoms:
+    """Class to represent crystal structure mimicing PhonopyAtoms."""
+
+    def __init__(
+        self,
+        numbers=None,
+        scaled_positions=None,
+        cell=None,
+    ):
+        """Init method."""
+        self._cell = np.array(cell, dtype="double")
+        self._scaled_positions = np.array(scaled_positions, dtype="double")
+        self._numbers = np.array(numbers, dtype="intc")
+
+    @property
+    def cell(self):
+        """Setter and getter of basis vectors. For getter, copy is returned."""
+        return self._cell.copy()
+
+    @property
+    def scaled_positions(self):
+        """Setter and getter of scaled positions. For getter, copy is returned."""
+        return self._scaled_positions.copy()
+
+    @property
+    def numbers(self):
+        """Setter and getter of atomic numbers. For getter, copy is returned."""
+        return self._numbers.copy()
+
+    def totuple(self):
+        """Return (cell, scaled_position, numbers)."""
+        return (self._cell, self._scaled_positions, self._numbers)


### PR DESCRIPTION
To avoid circular-import from Phonopy, 

- PhonopyAtoms was replaced by SymfcAtoms that mimics PhonopyAtoms minimally.
- Copy compute_sg_permutations from Phonopy and modify it to not use the C-implementation.