### PR TITLE
Keep compact compression matrix in FCBasisSetO3

### DIFF
--- a/src/symfc/basis_sets/basis_sets_O2.py
+++ b/src/symfc/basis_sets/basis_sets_O2.py
@@ -285,12 +285,11 @@ class FCBasisSetO2(FCBasisSetO2Base):
     def basis_set(self) -> Optional[np.ndarray]:
         """Return compressed basis set.
 
-        shape=(n_x*N*3*3, n_bases), dtype='double'.
+        n_c = len(compressed_indices).
 
-        Data in first dimension is ordered by (n_x,N,3,3).
+        shape=(n_c*N*3*3, n_bases), dtype='double'.
 
-        n_x (< n_a) is given as a result of compression, which is depends on the
-        system.
+        Data in first dimension is ordered by (n_c,N,3,3).
 
         """
         return self._basis_set
@@ -298,6 +297,8 @@ class FCBasisSetO2(FCBasisSetO2Base):
     @property
     def compact_basis_set(self) -> Optional[np.ndarray]:
         """Return compact basis set.
+
+        n_a : number of atoms in primitive cell.
 
         shape=(n_a*N*3*3, n_bases), dtype='double'.
 


### PR DESCRIPTION
Full compression matrix in FCBaisSetO3 is obtained by

`c_trans @ compact_compression_matrix`

on-the-fly.

FCBaisSetO3.compact_compression_matrix returns

`compact_compression_matrix / sqrt(n_lp)`

aiming being used to obtain compact fc3 directly usable by phono3py.